### PR TITLE
make sure sudoers_sudoers_d_files is properly quoted

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     owner: root
     group: root
     mode: 0440
-  with_dict: sudoers_sudoers_d_files
+  with_dict: "{{ sudoers_sudoers_d_files }}"
   tags: [configuration, sudoers, sudoers-configuration, sudoers-configuration-sudoers-d]
 
 - name: update global configuration file


### PR DESCRIPTION
In particular, the unquoted variable `sudoers_sudoers_d_files` breaks in Ansible 2.2 (that is, Ansible aborts with a `with_dict is expecting dict` error), and possibly earlier Ansible 2.x releases.